### PR TITLE
Update NUnit to latest 2.x version. 3 does not run well in ReSharper yet

### DIFF
--- a/NoCommons.Tests/NoCommons.Tests.csproj
+++ b/NoCommons.Tests/NoCommons.Tests.csproj
@@ -38,8 +38,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.6.1\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/NoCommons.Tests/packages.config
+++ b/NoCommons.Tests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.1" targetFramework="net40" />
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
- NUnit 3 does not run well in ReSharper yet, so kept source at NUnit 2.x.